### PR TITLE
AA lobster and then covariate work

### DIFF
--- a/Code/2_ExtractCovariates.R
+++ b/Code/2_ExtractCovariates.R
@@ -5,6 +5,13 @@ library(sf)
 library(raster)
 library(lubridate)
 library(gmRi)
+source("Code/enhance_r_funcs.R")
+
+file_path_sans_ext <- function(x, compression = FALSE) {
+  if (compression)
+    x <- sub("[.](gz|bz2|xz)$", "", x)
+  sub("([^.]+.+)\\.[[:alnum:]]+$", "\\1", x)
+}
 
 points_to_sf<- function(points){
   sf_out<- st_as_sf(points, coords = c("DECDEG_BEGLON", "DECDEG_BEGLAT"), crs = 4326, remove = FALSE)
@@ -71,3 +78,30 @@ all_tows_with_all_covs %>%
   
 
 unique(all_tows_with_all_covs$EST_YEAR[is.na(all_tows_with_all_covs$BT_seasonal) == T])
+
+#####
+## Dynamic covariates -- AA
+#####
+# It looks like the above is working, we just need to figure out what we want to do with the updated dataset bits. For now and to get things rolling, maybe we just chop to 1985-2020?
+
+# For what it is worth, here's if you wanted to do more than just BT...I hope? I really need to update the documentation on this stuff!
+
+# After making sure all of the raster stacks are in the "dynamic" folder and deleting the defunct ".dvc" nonsense. Also seeing the SST.gri file never uploaded to Box...of course!
+dynamic_dir<- paste0(proj_box_path, "covariates/dynamic")
+dynamic_stacks <- dynamic_covariates_read(dynamic_dir)
+
+# Run dynamic_2d_extract_wrapper function
+all_tows_with_all_covs <- dynamic_2d_extract_wrapper(dynamic_covariates_list = dynamic_stacks, t_summ = "seasonal", t_position = NULL, sf_points = all_tows_with_static_covs, date_col_name = "DATE", df_sf = "df", out_dir = "Data/Derived/")
+
+# Check it out
+summary(all_tows_with_all_covs)
+
+unique(all_tows_with_all_covs$EST_YEAR[is.na(all_tows_with_all_covs$SST_seasonal) == T])
+
+# Not entirely clear to me why we are missing some during the "good" years...potentially insure points?
+t <- all_tows_with_all_covs[which(is.na(all_tows_with_all_covs$SST_seasonal) == T), ] |>
+  filter(EST_YEAR >= 1985 & EST_YEAR <= 2019) |>
+  distinct()
+
+plot(t$DECDEG_BEGLON, t$DECDEG_BEGLAT) # Ahhhh fun :)
+

--- a/Code/AA_troubleshooting.r
+++ b/Code/AA_troubleshooting.r
@@ -1,0 +1,39 @@
+#####
+## Quick trouble shooting -- lobster weirdness and covariate functions
+#####
+
+library(tidyverse)
+library(gmRi)
+
+# Get Box path to Box/Mills Lab/Projects/COCA19_Projections/data/combined/tidy_mod_data.rds
+coca_path<- cs_path(box_group = "Mills Lab", subfolder = "Projects/COCA19_Projections/")
+coca_dat<- readRDS(paste0(coca_path, "data/combined/tidy_mod_data.rds"))
+summary(coca_dat)
+
+# Get lobster
+nefsc_code <- 301 # For reference, DFO code is 2550
+
+lob_dat <- coca_dat |>
+    filter(NMFS_SVSPP == nefsc_code)
+
+lob_summ<- lob_dat |>
+    group_by(EST_YEAR, SURVEY) |>
+    summarize("Lob_Bio" = sum(BIOMASS), "Lob_Abund" = sum(ABUNDANCE))
+
+ggplot() +
+    geom_bar(data = lob_summ, aes(x = EST_YEAR, y = Lob_Abund, fill = SURVEY), stat = "identity", position = "dodge")
+
+# Tows
+load(paste0(coca_path, "data/dfo/raw/RV.GSCAT.Rdata"))
+load(paste0(coca_path, "data/dfo/raw/RV.GSMISSIONS.Rdata"))
+
+both <- GSMISSIONS |>
+    left_join(GSCAT)
+
+head(both)
+
+tows <- unique(paste(both$MISSION, both$SETNO, both$YEAR, sep = "-"))
+write.csv(tows, "~/Desktop/COCA19_DFO_Tows.csv")
+
+### Covariate functions
+# Moved over to "2_ExtractCovariates.R" function


### PR DESCRIPTION
Hey Bart, 

Nothing major here -- I added a script where I went through getting the COCA19 data in case it is helpful for the lobster questions. Then I added a code chuck to the covariates part showing how to get both BT and SST extracted. I wonder if for now it makes sense to just filter years to 1985-2019, drop "other" NAs (e.g., the most nearshore obs that are chucking NA for SST) to get the structure up and running while we figure out where to go on the environmental data route? I know Adam has done a bunch there, so will likely chat with him/Claire and see what they recommend as we are going to need some nearshore stuff? The other thing we will want to keep an eye on is making sure whatever we choose we can also make the jump to the projection space?

Hope it helps!

Andrew